### PR TITLE
Added support for tex2svg

### DIFF
--- a/dollar.rkt
+++ b/dollar.rkt
@@ -13,7 +13,8 @@
          (only-in xml cdata)
          (only-in racket/match match)
          (only-in racket/system process)
-         (only-in racket/port port->string))
+         (only-in racket/port port->string)
+         (for-syntax racket/base))
 
 (provide $
          $$

--- a/dollar.rkt
+++ b/dollar.rkt
@@ -10,6 +10,7 @@
          "katex-convert-unicode.rkt"
          "mathjax-convert-unicode.rkt"
          racket/list
+         version-case
          (only-in xml cdata)
          (only-in racket/match match)
          (only-in racket/system process)
@@ -301,40 +302,42 @@ EOTEX
   (elem #:style math-inline-style-katex
                 (map (λ (s) (katex-convert-unicode s #t)) (flatten strs))))
 
-(define current-tex2svg-path (make-parameter #f))
+(version-case
+ [(version>= (version) "6.11.0.900"]
+  (define current-tex2svg-path (make-parameter #f))
 
-(define (find-tex2svg)
-  (define paths
-    (list
-     "./node_modules/.bin/"
-     "/usr/local/lib/node_modules/mathjax-node-cli/bin/"
-     "/usr/lib/node_modules/mathjax-node-cli/bin/"
-     "/usr/local/bin/"
-     "/usr/local/sbin/"
-     "/usr/bin/"
-     "/usr/sbin/"))
-  (for/or ([path paths])
-    (file-exists? (format "~a/tex2svg" path))))
+  (define (find-tex2svg)
+    (define paths
+      (list
+       "./node_modules/.bin/"
+       "/usr/local/lib/node_modules/mathjax-node-cli/bin/"
+       "/usr/lib/node_modules/mathjax-node-cli/bin/"
+       "/usr/local/bin/"
+       "/usr/local/sbin/"
+       "/usr/bin/"
+       "/usr/sbin/"))
+    (for/or ([path paths])
+      (file-exists? (format "~a/tex2svg" path))))
 
-(define tex2svg
-  (let ([tex2svg-path (find-tex2svg)])
-    (lambda (#:inline [inline #f] strs)
-      (if (or (current-tex2svg-path) tex2svg-path)
-          (match (process (format
-                           "tex2svg ~a'~a'"
-                           (if inline "--inline " "")
-                           (apply string-append strs)))
-            [`(,stdout . ,_)
-             (port->string stdout)])
-          (error 'tex2svg "Cannot find tex2svg in path or common places; set path manually with current-tex2svg-path.")))))
+  (define tex2svg
+    (let ([tex2svg-path (find-tex2svg)])
+      (lambda (#:inline [inline #f] strs)
+        (if (or (current-tex2svg-path) tex2svg-path)
+            (match (process (format
+                             "tex2svg ~a'~a'"
+                             (if inline "--inline " "")
+                                 (apply string-append strs)))
+              [`(,stdout . ,_)
+               (port->string stdout)])
+            (error 'tex2svg "Cannot find tex2svg in path or common places; set path manually with current-tex2svg-path.")))))
 
 
-(define ($-tex2svg strs)
-  (elem #:style (style #f
-                       (list
-                        (xexpr-property
-                         (cdata #f #f (tex2svg #:inline #t (flatten strs)))
-                         (cdata #f #f ""))))))
+  (define ($-tex2svg strs)
+    (elem #:style (style #f
+                         (list
+                          (xexpr-property
+                           (cdata #f #f (tex2svg #:inline #t (flatten strs)))
+                           (cdata #f #f ""))))))])
 
 (define ($$-mathjax strs)
   (elem #:style math-display-style-mathjax strs))
@@ -343,12 +346,14 @@ EOTEX
   (elem #:style math-display-style-katex
                 (map (λ (s) (katex-convert-unicode s #t)) (flatten strs))))
 
-(define ($$-tex2svg strs)
-  (elem #:style (style #f
-                       (list
-                        (xexpr-property
-                         (cdata #f #f (tex2svg (flatten strs)))
-                         (cdata #f #f ""))))))
+(version-case
+ [(version>= (version) "6.11.0.900"]
+  (define ($$-tex2svg strs)
+    (elem #:style (style #f
+                         (list
+                          (xexpr-property
+                           (cdata #f #f (tex2svg (flatten strs)))
+                           (cdata #f #f ""))))))])
 
 (define $-html-handler (make-parameter $-katex))
 (define $$-html-handler (make-parameter $$-katex))
@@ -363,10 +368,12 @@ EOTEX
   ($$-html-handler $$-mathjax)
   (void))
 
-(define (use-tex2svg)
-  ($-html-handler $-tex2svg)
-  ($$-html-handler $$-tex2svg)
-  (void))
+(version-case
+ [(version>= (version) "6.11.0.900"]
+  (define (use-tex2svg)
+    ($-html-handler $-tex2svg)
+    ($$-html-handler $$-tex2svg)
+    (void))])
 
 (define ($ . strs)
   (let ([$- ($-html-handler)])

--- a/dollar.rkt
+++ b/dollar.rkt
@@ -35,7 +35,7 @@
 (define-syntax (if-version≥6.12 stx)
   (syntax-case stx ()
     [(_ . rest)
-     (if (and (not (regexp-match #px"^6\.11\.0\.900$" (version)))
+     (if (and (not (regexp-match #px"^6\\.11\\.0\\.900$" (version)))
               (or (regexp-match #px"^6(\\.([0123456789]|10|11)(\\..*|)|)$" (version))
                   (regexp-match #px"^[123245]\\..*$" (version))))
          #'(begin)

--- a/dollar.rkt
+++ b/dollar.rkt
@@ -24,12 +24,8 @@
          $$-katex
          $-mathjax
          $$-mathjax
-         $-tex2svg
-         $$-tex2svg
          use-katex
          use-mathjax
-         use-tex2svg
-         current-tex2svg-path
          with-html5)
 
 (define-syntax (if-version≥6.12 stx)
@@ -40,6 +36,12 @@
                   (regexp-match #px"^[123245]\\..*$" (version))))
          #'(begin)
          #'(begin . rest))]))
+
+(if-version≥6.12
+  (provide $-tex2svg
+           $$-tex2svg
+           use-tex2svg
+           current-tex2svg-path))
 ;; KaTeX does not work well with the HTML 4.01 Transitional loose DTD,
 ;; so we define a style modifier which replaces the prefix for HTML rendering.
 (define (with-html5 doc-style)

--- a/dollar.rkt
+++ b/dollar.rkt
@@ -10,7 +10,6 @@
          "katex-convert-unicode.rkt"
          "mathjax-convert-unicode.rkt"
          racket/list
-         version-case
          (only-in xml cdata)
          (only-in racket/match match)
          (only-in racket/system process)
@@ -32,6 +31,12 @@
          current-tex2svg-path
          with-html5)
 
+(define-syntax (if-version≥6.12 stx)
+  (syntax-case stx ()
+    [(_ . rest)
+     (if (version>= (version) "6.11.0.900")
+         #'(begin . rest)
+         #'(begin))]))
 ;; KaTeX does not work well with the HTML 4.01 Transitional loose DTD,
 ;; so we define a style modifier which replaces the prefix for HTML rendering.
 (define (with-html5 doc-style)
@@ -302,8 +307,7 @@ EOTEX
   (elem #:style math-inline-style-katex
                 (map (λ (s) (katex-convert-unicode s #t)) (flatten strs))))
 
-(version-case
- [(version>= (version) "6.11.0.900"]
+(if-version≥6.12
   (define current-tex2svg-path (make-parameter #f))
 
   (define (find-tex2svg)
@@ -337,7 +341,7 @@ EOTEX
                          (list
                           (xexpr-property
                            (cdata #f #f (tex2svg #:inline #t (flatten strs)))
-                           (cdata #f #f ""))))))])
+                           (cdata #f #f "")))))))
 
 (define ($$-mathjax strs)
   (elem #:style math-display-style-mathjax strs))
@@ -346,14 +350,13 @@ EOTEX
   (elem #:style math-display-style-katex
                 (map (λ (s) (katex-convert-unicode s #t)) (flatten strs))))
 
-(version-case
- [(version>= (version) "6.11.0.900"]
+(if-version≥6.12
   (define ($$-tex2svg strs)
     (elem #:style (style #f
                          (list
                           (xexpr-property
                            (cdata #f #f (tex2svg (flatten strs)))
-                           (cdata #f #f ""))))))])
+                           (cdata #f #f "")))))))
 
 (define $-html-handler (make-parameter $-katex))
 (define $$-html-handler (make-parameter $$-katex))
@@ -368,12 +371,11 @@ EOTEX
   ($$-html-handler $$-mathjax)
   (void))
 
-(version-case
- [(version>= (version) "6.11.0.900"]
+(if-version≥6.12
   (define (use-tex2svg)
     ($-html-handler $-tex2svg)
     ($$-html-handler $$-tex2svg)
-    (void))])
+    (void)))
 
 (define ($ . strs)
   (let ([$- ($-html-handler)])

--- a/dollar.rkt
+++ b/dollar.rkt
@@ -35,9 +35,11 @@
 (define-syntax (if-version≥6.12 stx)
   (syntax-case stx ()
     [(_ . rest)
-     (if (version>= (version) "6.11.0.900")
-         #'(begin . rest)
-         #'(begin))]))
+     (if (and (not (regexp-match #px"^6\.11\.0\.900$" (version)))
+              (or (regexp-match #px"^6(\\.([0123456789]|10|11)(\\..*|)|)$" (version))
+                  (regexp-match #px"^[123245]\\..*$" (version))))
+         #'(begin)
+         #'(begin . rest))]))
 ;; KaTeX does not work well with the HTML 4.01 Transitional loose DTD,
 ;; so we define a style modifier which replaces the prefix for HTML rendering.
 (define (with-html5 doc-style)

--- a/info.rkt
+++ b/info.rkt
@@ -11,6 +11,6 @@
 (define test-omit-paths '("MathJax" "katex"))
 (define scribblings '(("scribblings/scribble-math.scrbl" ())))
 (define pkg-desc "Typesetting math and Asymptote figures in Scribble documents")
-(define version "0.9")
+(define version "0.10")
 (define pkg-authors '(|Georges Dupéron|
                       |Jens Axel Søgaard|))

--- a/info.rkt
+++ b/info.rkt
@@ -2,8 +2,7 @@
 (define collection "scribble-math")
 (define deps '("base"
                "rackunit-lib"
-               "scribble-lib"
-               "version-case"))
+               "scribble-lib"))
 (define build-deps '("scribble-lib"
                      "racket-doc"
                      "at-exp-lib"

--- a/info.rkt
+++ b/info.rkt
@@ -2,7 +2,8 @@
 (define collection "scribble-math")
 (define deps '("base"
                "rackunit-lib"
-               "scribble-lib"))
+               "scribble-lib"
+               "version-case"))
 (define build-deps '("scribble-lib"
                      "racket-doc"
                      "at-exp-lib"

--- a/scribblings/scribble-math.scrbl
+++ b/scribblings/scribble-math.scrbl
@@ -164,6 +164,24 @@ details see the documentation of @racket[with-html5].
  that when the page is loaded into a browser, MathJax can
  recognise it and render it in @tech{display mode}.}
 
+@defproc[($-tex2svg [math (listof? string?)]) element?]{
+ Produces an @racket[element?] renders an HTML SVG literal.
+ It is rendered in @tech{inline mode} math using @tt{tex2svg}.
+ More precisely, the resulting element uses the @racket[xexpr-property] to
+ render the SVG directly to the HTML document.
+ This means no new scripts or stylesheets are added to the document.
+ It also has no style, so its style cannot be customized.
+ }
+
+@defproc[($$-tex2svg [math (listof? string?)]) element?]{
+Produces an @racket[element?] renders an HTML SVG literal.
+It is rendered in @tech{display mode} math using @tt{tex2svg}.
+More precisely, the resulting element uses the @racket[xexpr-property] to
+render the SVG directly to the HTML document.
+This means no new scripts or stylesheets are added to the document.
+It also has no style, so its style cannot be customized.
+}
+
 @defproc[(use-katex) void?]{
  This shorthand calls @racket[($-html-handler $-katex)]
  and @racket[($$-html-handler $$-katex)]. The mathematical
@@ -194,6 +212,35 @@ details see the documentation of @racket[with-html5].
  page if the user changes the default before typesetting any
  math.}
 
+@defproc[(use-tex2svg) void?]{
+ This shorthand calls @racket[($-html-handler $-tex2svg)] and
+ @racket[($$-html-handler $$-tex2svg)]. The mathematical forumulas passed to
+ @racket[$] and @racket[$$] which appear later in the document will therefore be
+ typeset using @tt{tex2svg}.
+
+ No new CSS or JavaScript libraries will be added to the document. Instead, the
+ generated HTML document have the math embedded directly an @tt{svg}.
+
+ This requires that @tt{tex2svg} is installed on the system. You can install it
+ globally via @tt{sudo npm install --global mathjax-node-cli} or locally with
+ @tt{npm install mathjax-node-cli}. The backend will attempt to find the
+ @tt{tex2svg}, preferring local sources. You can set the path manually with
+ the parameter @racket[current-tex2svg-path].
+
+ @tt{tex2svg} will only be used when rendering an HTML document, and only if it
+ uses @racket[$] or @racket[$$] to render math. It is therefore safe to call
+ this function in libraries to change the default handler.
+}
+
+@defparam[current-tex2svg-path path path? #:value #f]{
+A parameter whose value is the path to the @tt{tex2svg} binary.
+This binary is used to transform math code into HTML when using the @tt{tex2svg}
+backend.
+The functions @racket[$] and @racket[$$] use this parameter only when rendering
+the document as HTML.
+}
+
+
 @;@$${\sum_{i=0}ⁿ xᵢ³}
 
 When using MathJax, @racket[$] and @racket[$$] wrap their
@@ -203,6 +250,10 @@ respectively, and insert it in an element with the class
 process elements with this class, so it is safe to use
 @tt{$} signs in the source document. For example, the text
 $\sum x^3$ is typeset as-is, like the rest of the text.
+
+When using @tt{tex2svg}, no additional JavaScript processing is done on the
+page, so it is safe to use @tt{$} signs in the source document. For example, the
+text $\sum x^3$ is typeset as-is, like the rest of the text.
 
 @section{Drawing figures with Asymptote}
 

--- a/scribblings/scribble-math.scrbl
+++ b/scribblings/scribble-math.scrbl
@@ -172,17 +172,19 @@ details see the documentation of @racket[with-html5].
  render the SVG directly to the HTML document.
  This means no new scripts or stylesheets are added to the document.
  It also has no style, so its style cannot be customized.
- }
+
+ This procedure requires Racket 6.12 or later.}
 
 @defproc[($$-tex2svg [math (listof? string?)]) element?]{
-Produces an @racket[element?] which contains the given
-@racket[math] rendered as an HTML SVG literal.
-It is rendered in @tech{display mode} math using @tt{tex2svg}.
-More precisely, the resulting element uses the @racket[xexpr-property] to
-render the SVG directly to the HTML document.
-This means no new scripts or stylesheets are added to the document.
-It also has no style, so its style cannot be customized.
-}
+ Produces an @racket[element?] which contains the given
+ @racket[math] rendered as an HTML SVG literal.
+ It is rendered in @tech{display mode} math using @tt{tex2svg}.
+ More precisely, the resulting element uses the @racket[xexpr-property] to
+ render the SVG directly to the HTML document.
+ This means no new scripts or stylesheets are added to the document.
+ It also has no style, so its style cannot be customized.
+
+ This procedure requires Racket 6.12 or later.}
 
 @defproc[(use-katex) void?]{
  This shorthand calls @racket[($-html-handler $-katex)]
@@ -232,15 +234,18 @@ It also has no style, so its style cannot be customized.
  @tt{tex2svg} will only be used when rendering an HTML document, and only if it
  uses @racket[$] or @racket[$$] to render math. It is therefore safe to call
  this function in libraries to change the default handler.
-}
+
+ This procedure requires Racket 6.12 or later.}
 
 @defparam[current-tex2svg-path path path? #:value #f]{
-A parameter whose value is the path to the @tt{tex2svg} binary.
-This binary is used to transform math code into HTML when using the @tt{tex2svg}
-backend.
-The functions @racket[$-tex2svg] and @racket[$$-tex2svg] use this parameter only
-when rendering the document as HTML.
-}
+ A parameter whose value is the path to the @tt{tex2svg} binary.
+ This binary is used to transform math code into HTML when using the @tt{tex2svg}
+ backend.
+ 
+ The functions @racket[$-tex2svg] and @racket[$$-tex2svg] use this parameter only
+ when rendering the document as HTML.
+
+ This parameter requires Racket 6.12 or later.}
 
 
 @;@$${\sum_{i=0}ⁿ xᵢ³}

--- a/scribblings/scribble-math.scrbl
+++ b/scribblings/scribble-math.scrbl
@@ -165,7 +165,8 @@ details see the documentation of @racket[with-html5].
  recognise it and render it in @tech{display mode}.}
 
 @defproc[($-tex2svg [math (listof? string?)]) element?]{
- Produces an @racket[element?] renders an HTML SVG literal.
+ Produces an @racket[element?] which contains the given
+ @racket[math] rendered as an HTML SVG literal.
  It is rendered in @tech{inline mode} math using @tt{tex2svg}.
  More precisely, the resulting element uses the @racket[xexpr-property] to
  render the SVG directly to the HTML document.
@@ -174,7 +175,8 @@ details see the documentation of @racket[with-html5].
  }
 
 @defproc[($$-tex2svg [math (listof? string?)]) element?]{
-Produces an @racket[element?] renders an HTML SVG literal.
+Produces an @racket[element?] which contains the given
+@racket[math] rendered as an HTML SVG literal.
 It is rendered in @tech{display mode} math using @tt{tex2svg}.
 More precisely, the resulting element uses the @racket[xexpr-property] to
 render the SVG directly to the HTML document.
@@ -236,8 +238,8 @@ It also has no style, so its style cannot be customized.
 A parameter whose value is the path to the @tt{tex2svg} binary.
 This binary is used to transform math code into HTML when using the @tt{tex2svg}
 backend.
-The functions @racket[$] and @racket[$$] use this parameter only when rendering
-the document as HTML.
+The functions @racket[$-tex2svg] and @racket[$$-tex2svg] use this parameter only
+when rendering the document as HTML.
 }
 
 


### PR DESCRIPTION
This adds (and documents) support for using `tex2svg`, from the node package `mathjax-node-cli`, to statically render math to SVG in the HTML backend.